### PR TITLE
Fix wrong class name in `class_exists` call

### DIFF
--- a/plugins/detect/detect.php
+++ b/plugins/detect/detect.php
@@ -9,7 +9,7 @@
  */
 
 // Load the Mobile_Detect.php script
-if (!class_exists('device_class')) require_once('lib/Mobile_Detect.php');
+if (!class_exists('Mobile_Detect')) require_once('lib/Mobile_Detect.php');
 
 // Now create a new mobile detect class
 $detect = new Mobile_Detect();


### PR DESCRIPTION
Seems like a typo: `device_class` -> `Mobile_Detect`
